### PR TITLE
ci(actions): add PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+documentation:
+- changed-files:
+  - any-glob-to-any-file: '**/*.md'
+
+Avalonia:
+- changed-files:
+  - any-glob-to-any-file: SnapX.Avalonia/**
+
+Core:
+- changed-files:
+  - any-glob-to-any-file: SnapX.Core/**
+
+enhancement:
+ - head-branch: ['^feat']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4 # Uploads repository content to the runner
+      with:
+        repository: ${{ github.repository }}
+    - uses: actions/labeler@v5
+      with:
+        sync-labels: true


### PR DESCRIPTION
Added PR labeler action from GitHub. You can remove The Label Bot now.
See https://github.com/marketplace/actions/labeler for more details on configuration.