### PR TITLE
ci(actions): make PR labeler have even more options

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,3 +22,6 @@ actions:
 packaging:
   - changed-files:
     - any-glob-to-any-file: packaging/**
+
+dependencies:
+  - head-branch: ['^dep', '^depend', 'depend', 'dependency', 'dependencies']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,7 @@
 documentation:
 - changed-files:
   - any-glob-to-any-file: '**/*.md'
+  - any-glob-to-any-file: '**/README.txt'
 
 Avalonia:
 - changed-files:
@@ -11,8 +12,13 @@ Core:
   - any-glob-to-any-file: SnapX.Core/**
 
 enhancement:
- - head-branch: ['^feat']
+ - head-branch: ['^feat', 'feat', 'feature']
 
 actions:
 - changed-files:
   - any-glob-to-any-file: .github/workflows/**
+  - any-glob-to-any-file: .github/labeler.yml
+
+packaging:
+  - changed-files:
+    - any-glob-to-any-file: packaging/**


### PR DESCRIPTION
Add `packaging` and `dependencies` label and fix some labels.