### PR TITLE
feat(WinGet): add WinGet Releaser

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Run WinGet Releaser
-        uses: vedantmgoyal9/winget-releaser@main
+        uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5
         with:
           identifier: SnapXL.SnapX
           max-versions-to-keep: 5

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,14 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Run WinGet Releaser
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: SnapXL.SnapX
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
# Preface
This PR introduces WinGet Releaser, a GitHub Action that publishes new releases of an application to the Windows Package Manager automatically, without any hassle. This makes the automation process much easier.

## Description of Change
This PR allows for automatic WinGet update submission.

## Possible Alternatives
Just doing it by hand, but it would take a lot of time and will be more error-prone.

## Notes
- Related to #473