### PR TITLE
feat(upload): add voided.host uploaders with shared config and settings UI

### DIFF
--- a/SnapX.Avalonia/Views/Settings/Views/BuiltInUploaderSettingsView.axaml.cs
+++ b/SnapX.Avalonia/Views/Settings/Views/BuiltInUploaderSettingsView.axaml.cs
@@ -83,6 +83,9 @@ public partial class BuiltInUploaderSettingsView : UserControl
             GitHubGist => new GithubGistUploaderSettingsView() { DataContext = instance },
             Hastebin => new HastebinUploaderSettingsView() { DataContext = instance },
             OneTimeSecret => new OneTimeSecretUploadSettingsView() { DataContext = instance },
+            VoidedHostUploader => new ImageUploaders.VoidedHostUploaderSettingsView { DataContext = instance },
+            VoidedHostTextUploader => new ImageUploaders.VoidedHostUploaderSettingsView { DataContext = instance },
+            VoidedHostFileUploader => new ImageUploaders.VoidedHostUploaderSettingsView { DataContext = instance },
             FTP or SFTP => new FTPSettingsView() { DataContext = instance },
             // Add other mappings here:
             // AmazonS3 => new S3SettingsView { DataContext = instance },

--- a/SnapX.Avalonia/Views/Settings/Views/ImageUploaders/VoidedHostUploaderSettingsView.axaml
+++ b/SnapX.Avalonia/Views/Settings/Views/ImageUploaders/VoidedHostUploaderSettingsView.axaml
@@ -1,0 +1,47 @@
+<UserControl
+    x:Class="SnapX.Avalonia.Views.Settings.Views.ImageUploaders.VoidedHostUploaderSettingsView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <StackPanel Spacing="4">
+        <controls:SettingsExpander
+            Description="These settings apply to image, text, and file uploads via voided.host."
+            Header="Account"
+            IconSource="Contact"
+            IsExpanded="True">
+            <controls:SettingsExpanderItem Content="Don't have an account?">
+                <controls:SettingsExpanderItem.Footer>
+                    <Button
+                        Classes="accent"
+                        Click="RegisterButton_OnClick"
+                        Content="Create account"
+                        x:Name="RegisterButton" />
+                </controls:SettingsExpanderItem.Footer>
+            </controls:SettingsExpanderItem>
+            <controls:SettingsExpanderItem Content="Upload as guest" Description="Use shared guest account instead of your personal key">
+                <controls:SettingsExpanderItem.Footer>
+                    <CheckBox
+                        x:Name="cbUseGuest" />
+                </controls:SettingsExpanderItem.Footer>
+            </controls:SettingsExpanderItem>
+            <controls:SettingsExpanderItem Content="Upload Key" x:Name="UploadKeyItem">
+                <controls:SettingsExpanderItem.Footer>
+                    <TextBox
+                        PasswordChar="*"
+                        VerticalAlignment="Center"
+                        Watermark="Paste your upload key here..."
+                        Width="350"
+                        x:Name="txtUploadKey" />
+                </controls:SettingsExpanderItem.Footer>
+            </controls:SettingsExpanderItem>
+            <controls:SettingsExpanderItem Content="Manage your upload keys on voided.host" x:Name="ManageKeysItem">
+                <controls:SettingsExpanderItem.Footer>
+                    <Button
+                        Click="ManageKeysButton_OnClick"
+                        Content="Open key settings" />
+                </controls:SettingsExpanderItem.Footer>
+            </controls:SettingsExpanderItem>
+        </controls:SettingsExpander>
+    </StackPanel>
+</UserControl>

--- a/SnapX.Avalonia/Views/Settings/Views/ImageUploaders/VoidedHostUploaderSettingsView.axaml.cs
+++ b/SnapX.Avalonia/Views/Settings/Views/ImageUploaders/VoidedHostUploaderSettingsView.axaml.cs
@@ -1,0 +1,65 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using SnapX.Core.Upload.Img;
+using SnapX.Core.Utils;
+
+namespace SnapX.Avalonia.Views.Settings.Views.ImageUploaders;
+
+public partial class VoidedHostUploaderSettingsView : UserControl
+{
+    public VoidedHostUploaderSettingsView()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+
+        if (DataContext is not (VoidedHostUploader or SnapX.Core.Upload.Text.VoidedHostTextUploader or SnapX.Core.Upload.File.VoidedHostFileUploader)) return;
+        var config = SnapX.Core.SnapXL.UploadersConfig;
+
+        bool guestKeyOk = VoidedHostUploader.IsGuestUploadKeyConfigured();
+        if (!guestKeyOk && config.VoidedHostUseGuest)
+        {
+            config.VoidedHostUseGuest = false;
+        }
+
+        cbUseGuest.IsChecked = guestKeyOk && config.VoidedHostUseGuest;
+        cbUseGuest.IsEnabled = guestKeyOk;
+        txtUploadKey.Text = config.VoidedHostUploadKey ?? "";
+
+        UpdateControlStates();
+
+        cbUseGuest.IsCheckedChanged += (_, _) =>
+        {
+            config.VoidedHostUseGuest = cbUseGuest.IsChecked == true;
+            UpdateControlStates();
+        };
+
+        txtUploadKey.TextChanged += (_, _) =>
+        {
+            config.VoidedHostUploadKey = txtUploadKey.Text ?? "";
+        };
+    }
+
+    private void UpdateControlStates()
+    {
+        bool guestKeyOk = VoidedHostUploader.IsGuestUploadKeyConfigured();
+        bool guest = guestKeyOk && cbUseGuest.IsChecked == true;
+
+        txtUploadKey.IsEnabled = !guest;
+        UploadKeyItem.IsEnabled = !guest;
+        ManageKeysItem.IsEnabled = !guest;
+    }
+
+    private void RegisterButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        URLHelpers.OpenURL(VoidedHostUploader.SnapXSetupRegisterUrl);
+    }
+
+    private void ManageKeysButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        URLHelpers.OpenURL(VoidedHostUploader.UploadKeySettingsUrl);
+    }
+}

--- a/SnapX.Avalonia/Views/Settings/Views/SettingsMainView.axaml
+++ b/SnapX.Avalonia/Views/Settings/Views/SettingsMainView.axaml
@@ -353,8 +353,6 @@
                             <controls:NavigationViewItem Content="{Binding Source={x:Static upload:FileDestination.SharedFolder}, Converter={StaticResource EnumDescConverter}}" Tag="{x:Static upload:FileDestination.SharedFolder}" />
                             <controls:NavigationViewItem Content="{Binding Source={x:Static upload:FileDestination.Email}, Converter={StaticResource EnumDescConverter}}" Tag="{x:Static upload:FileDestination.Email}" />
 
-
-
                         </controls:NavigationViewItem.MenuItems>
                     </controls:NavigationViewItem>
                     <controls:NavigationViewItem Content="{Binding Source={x:Static upload:UploaderCategory.URLShorteners}, Converter={StaticResource EnumDescConverter}}" Tag="{x:Static upload:UploaderCategory.URLShorteners}">
@@ -372,6 +370,17 @@
                             <controls:NavigationViewItem Content="{Binding Source={x:Static upload:UrlShortenerType.ZeroWidthShortener}, Converter={StaticResource EnumDescConverter}}" Tag="{x:Static upload:UrlShortenerType.ZeroWidthShortener}" />
 
 
+                        </controls:NavigationViewItem.MenuItems>
+                    </controls:NavigationViewItem>
+                    <controls:NavigationViewItem Content="{Binding Source={x:Static upload:UploaderCategory.UniversalUploaders}, Converter={StaticResource EnumDescConverter}}" Tag="{x:Static upload:UploaderCategory.UniversalUploaders}">
+                        <controls:NavigationViewItem.IconSource>
+                            <fluent:FluentIconSource
+                                Icon="Apps"
+                                IconSize="Size24"
+                                IconVariant="Regular" />
+                        </controls:NavigationViewItem.IconSource>
+                        <controls:NavigationViewItem.MenuItems>
+                            <controls:NavigationViewItem Content="{Binding Source={x:Static upload:ImageDestination.VoidedHost}, Converter={StaticResource EnumDescConverter}}" Tag="{x:Static upload:ImageDestination.VoidedHost}" />
                         </controls:NavigationViewItem.MenuItems>
                     </controls:NavigationViewItem>
                     <controls:NavigationViewItem Content="Custom uploaders" Tag="CustomUploader">

--- a/SnapX.Core/Upload/Enums.cs
+++ b/SnapX.Core/Upload/Enums.cs
@@ -17,6 +17,8 @@ public enum ImageDestination
     Chevereto,
     [Description("vgy.me")]
     Vgyme,
+    [Description("voided.host")]
+    VoidedHost,
     CustomImageUploader, // Localized
     FileUploader // Localized
 }
@@ -36,6 +38,8 @@ public enum TextDestination
     Hastebin,
     [Description("OneTimeSecret")]
     OneTimeSecret,
+    [Description("voided.host")]
+    VoidedHost,
     CustomTextUploader, // Localized
     FileUploader // Localized
 }
@@ -95,6 +99,8 @@ public enum FileDestination
     YouTube,
     [Description("Vault.ooo")]
     Vault_ooo,
+    [Description("voided.host")]
+    VoidedHost,
     SharedFolder, // Localized
     Email, // Localized
     CustomFileUploader // Localized

--- a/SnapX.Core/Upload/File/VoidedHostFileUploader.cs
+++ b/SnapX.Core/Upload/File/VoidedHostFileUploader.cs
@@ -1,0 +1,55 @@
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+
+using System.Diagnostics.CodeAnalysis;
+using SnapX.Core.Upload.BaseServices;
+using SnapX.Core.Upload.BaseUploaders;
+using SnapX.Core.Upload.Img;
+using SnapX.Core.Upload.Utils;
+
+namespace SnapX.Core.Upload.File;
+
+public class VoidedHostFileUploaderService : FileUploaderService
+{
+    public override FileDestination EnumValue => FileDestination.VoidedHost;
+
+    public override bool CheckConfig(UploadersConfig config) => VoidedHostUploader.IsUploadConfigured(config);
+
+    public override GenericUploader CreateUploader(UploadersConfig config, TaskReferenceHelper taskInfo)
+    {
+        bool useGuest = VoidedHostUploader.ShouldUseGuestMode(config);
+        string key = VoidedHostUploader.GetEffectiveUploadKey(config);
+
+        return new VoidedHostFileUploader(key, useGuest);
+    }
+}
+
+public sealed class VoidedHostFileUploader : FileUploader
+{
+    private readonly VoidedHostMultipartUploader _multipart;
+
+    public VoidedHostFileUploader(string uploadKey, bool useGuestMode)
+    {
+        _multipart = new VoidedHostMultipartUploader(uploadKey, useGuestMode, VoidedHostUploader.FileUploadApiUrl);
+        _multipart.ProgressChanged += OnProgressChanged;
+        _multipart.EarlyURLCopyRequested += OnEarlyURLCopyRequested;
+    }
+
+    [RequiresDynamicCode("Uploader")]
+    [RequiresUnreferencedCode("Uploader")]
+    public override UploadResult Upload(Stream stream, string? fileName)
+    {
+        Errors.Errors.Clear();
+        _multipart.BufferSize = BufferSize;
+        UploadResult result = _multipart.Upload(stream, fileName);
+        Errors.Add(_multipart.Errors);
+        return result;
+    }
+
+    public override void StopUpload()
+    {
+        _multipart.StopUpload();
+        base.StopUpload();
+    }
+}

--- a/SnapX.Core/Upload/Img/VoidedHostUploader.cs
+++ b/SnapX.Core/Upload/Img/VoidedHostUploader.cs
@@ -1,0 +1,426 @@
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+
+using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SnapX.Core.Upload.BaseServices;
+using SnapX.Core.Upload.BaseUploaders;
+using SnapX.Core.Upload.Utils;
+
+namespace SnapX.Core.Upload.Img;
+
+public class VoidedHostImageUploaderService : ImageUploaderService
+{
+    public override ImageDestination EnumValue => ImageDestination.VoidedHost;
+
+    public override bool CheckConfig(UploadersConfig config) => VoidedHostUploader.IsUploadConfigured(config);
+
+    public override GenericUploader CreateUploader(UploadersConfig config, TaskReferenceHelper taskInfo)
+    {
+        bool useGuest = VoidedHostUploader.ShouldUseGuestMode(config);
+        string key = VoidedHostUploader.GetEffectiveUploadKey(config);
+
+        return new VoidedHostUploader(key, useGuest);
+    }
+}
+
+internal sealed class VoidedHostMultipartUploader : FileUploader
+{
+    private readonly string _uploadKey;
+    private readonly bool _useGuestMode;
+    private readonly string _apiUrl;
+
+    public VoidedHostMultipartUploader(string uploadKey, bool useGuestMode, string apiUrl)
+    {
+        _uploadKey = uploadKey ?? "";
+        _useGuestMode = useGuestMode;
+        _apiUrl = apiUrl ?? "";
+    }
+
+    [RequiresDynamicCode("Uploader")]
+    [RequiresUnreferencedCode("Uploader")]
+    public override UploadResult Upload(Stream stream, string? fileName)
+    {
+        var result = new UploadResult();
+        Errors.Errors.Clear();
+
+        DebugHelper.WriteLine($"[voided.host] Upload starting. ApiUrl={_apiUrl}, FileName={fileName}, GuestMode={_useGuestMode}, StreamLength={stream?.Length}, StreamPosition={stream?.Position}");
+
+        if (string.IsNullOrWhiteSpace(_uploadKey))
+        {
+            DebugHelper.WriteLine("[voided.host] Upload key is empty, aborting.");
+            if (_useGuestMode)
+            {
+                Errors.Add("Guest uploads aren't enabled in this build of SnapX. Turn off guest upload, then paste your own voided.host upload key (or use a build that includes guest uploads).");
+            }
+            else
+            {
+                Errors.Add("Paste your voided.host upload key in SnapX destinations, or turn on guest upload if your build supports it.");
+            }
+
+            return result;
+        }
+
+        var headers = new NameValueCollection
+        {
+            ["Authorization"] = _uploadKey.Trim()
+        };
+
+        var args = new Dictionary<string, string?>
+        {
+            ["p"] = "snapx",
+            ["v"] = "1",
+            ["t"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()
+        };
+
+        ReturnResponseOnError = true;
+        DebugHelper.WriteLine($"[voided.host] Sending request to {_apiUrl}");
+        result = SendRequestFile(_apiUrl, stream, fileName, "file", args, headers);
+
+        var statusCode = result.ResponseInfo?.StatusCode;
+        DebugHelper.WriteLine($"[voided.host] Response received. IsSuccess={result.IsSuccess}, StatusCode={statusCode}, ResponseLength={result.Response?.Length ?? 0}");
+
+        if (!string.IsNullOrEmpty(result.Response))
+        {
+            var preview = result.Response.Length > 500 ? result.Response[..500] + "..." : result.Response;
+            DebugHelper.WriteLine($"[voided.host] Response body: {preview}");
+        }
+
+        if (VoidedHostResponseParser.TryBuildUserFacingError(result.Response, out var structuredError))
+        {
+            DebugHelper.WriteLine($"[voided.host] API returned structured error: {structuredError}");
+            Errors.Errors.Clear();
+            Errors.Add(structuredError);
+            result.IsSuccess = false;
+            return result;
+        }
+
+        ApplyUnauthorizedRotationHint(result);
+
+        if (!result.IsSuccess || string.IsNullOrEmpty(result.Response))
+        {
+            DebugHelper.WriteLine($"[voided.host] Upload failed or empty response. IsSuccess={result.IsSuccess}, HasResponse={!string.IsNullOrEmpty(result.Response)}, ErrorCount={Errors.Count}");
+            return result;
+        }
+
+        if (!VoidedHostResponseParser.TryParseUploadResponse(result.Response, out var shareLink, out var deletionUrl, out var apiUserError))
+        {
+            DebugHelper.WriteLine($"[voided.host] Failed to parse upload response. ApiError={apiUserError}");
+            if (!string.IsNullOrEmpty(apiUserError))
+            {
+                Errors.Add(apiUserError);
+            }
+            else
+            {
+                Errors.Add("voided.host replied in an unexpected format. Try updating SnapX; if it keeps happening, forward the upload log to voided.host support.");
+            }
+
+            result.IsSuccess = false;
+            return result;
+        }
+
+        DebugHelper.WriteLine($"[voided.host] Upload successful. URL={shareLink}, DeletionURL={deletionUrl}");
+        result.URL = shareLink;
+        if (!string.IsNullOrWhiteSpace(deletionUrl))
+        {
+            result.DeletionURL = deletionUrl;
+        }
+
+        result.IsSuccess = true;
+        return result;
+    }
+
+    private void ApplyUnauthorizedRotationHint(UploadResult result)
+    {
+        var info = LastResponseInfo ?? result.ResponseInfo;
+        if (info?.StatusCode != HttpStatusCode.Unauthorized)
+        {
+            return;
+        }
+
+        DebugHelper.WriteLine($"[voided.host] 401 Unauthorized. GuestMode={_useGuestMode}");
+        Errors.Errors.Clear();
+
+        if (_useGuestMode)
+        {
+            Errors.Add("voided.host blocked guest uploads (access expired or changed). Turn off guest upload and paste your personal upload key, or install the latest SnapX. More help: " + VoidedHostUploader.UploadKeySettingsUrl);
+        }
+        else
+        {
+            Errors.Add("voided.host didn't accept your upload key—it may have been reset. Open your upload-key page, copy the current key, and paste it in SnapX: " + VoidedHostUploader.UploadKeySettingsUrl);
+        }
+    }
+}
+
+public sealed class VoidedHostUploader : ImageUploader
+{
+    /// <summary>
+    /// Upload key used when the user enables "Upload as guest". Must be provisioned by voided.host
+    /// for the shared guest account. Guest mode stays off in the UI and in CheckConfig until this is non-empty.
+    /// Omit from public repos — set at release build time only.
+    /// </summary>
+    public const string GuestUploadApiKey = "MTA3NQ.MTc3ODMzMzE1MDI3NA.wIeJFNAwaYymgvgMIhLCxRamvUXWtZMtSGmjQNZDfGDKGVqx";
+
+    public const string ImageUploadApiUrl = "https://api.voided.host/v2/images";
+    public const string PasteUploadApiUrl = "https://api.voided.host/v2/pastes";
+    public const string FileUploadApiUrl = "https://api.voided.host/v2/files";
+    public const string UploadKeySettingsUrl = "https://voided.host/settings/security";
+    public const string SnapXSetupRegisterUrl = "https://voided.host/register?inviter=Lixqa&next=/flows/sharex-uploader-setup/";
+    public const string ImageDeletionUrlFormat = "https://voided.host/settings/image/{0}";
+
+    private readonly VoidedHostMultipartUploader _multipart;
+
+    public string UploadKey { get; private set; }
+
+    public bool UseGuestMode { get; private set; }
+
+    public VoidedHostUploader(string uploadKey, bool useGuestMode)
+    {
+        UploadKey = uploadKey ?? "";
+        UseGuestMode = useGuestMode;
+        _multipart = new VoidedHostMultipartUploader(uploadKey, useGuestMode, ImageUploadApiUrl);
+        _multipart.ProgressChanged += OnProgressChanged;
+        _multipart.EarlyURLCopyRequested += OnEarlyURLCopyRequested;
+    }
+
+    public static bool IsUploadConfigured(UploadersConfig config)
+    {
+        if (config == null)
+        {
+            return false;
+        }
+
+        if (ShouldUseGuestMode(config))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrWhiteSpace(config.VoidedHostUploadKey);
+    }
+
+    public static bool ShouldUseGuestMode(UploadersConfig config)
+    {
+        return config != null && config.VoidedHostUseGuest && IsGuestUploadKeyConfigured();
+    }
+
+    public static bool IsGuestUploadKeyConfigured()
+    {
+        return !string.IsNullOrWhiteSpace(GuestUploadApiKey);
+    }
+
+    public static string GetEffectiveUploadKey(UploadersConfig config)
+    {
+        if (ShouldUseGuestMode(config))
+        {
+            return GuestUploadApiKey.Trim();
+        }
+
+        return config?.VoidedHostUploadKey?.Trim() ?? "";
+    }
+
+    [RequiresDynamicCode("Uploader")]
+    [RequiresUnreferencedCode("Uploader")]
+    public override UploadResult Upload(Stream stream, string? fileName)
+    {
+        Errors.Errors.Clear();
+        _multipart.BufferSize = BufferSize;
+        UploadResult result = _multipart.Upload(stream, fileName);
+        Errors.Add(_multipart.Errors);
+        return result;
+    }
+
+    public override void StopUpload()
+    {
+        _multipart.StopUpload();
+        base.StopUpload();
+    }
+}
+
+[JsonSerializable(typeof(VoidedHostApiResponse))]
+internal partial class VoidedHostJsonContext : JsonSerializerContext;
+
+internal sealed class VoidedHostApiResponse
+{
+    [JsonPropertyName("error")]
+    public JsonElement? Error { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    [JsonPropertyName("_errors")]
+    public List<VoidedHostApiErrorDetail>? ErrorDetails { get; set; }
+
+    [JsonPropertyName("data")]
+    public VoidedHostApiData? Data { get; set; }
+}
+
+internal sealed class VoidedHostApiErrorDetail
+{
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}
+
+internal sealed class VoidedHostApiData
+{
+    [JsonPropertyName("shareLink")]
+    public string? ShareLink { get; set; }
+
+    [JsonPropertyName("id")]
+    public JsonElement? Id { get; set; }
+}
+
+internal static class VoidedHostResponseParser
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        TypeInfoResolver = VoidedHostJsonContext.Default,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static bool TryBuildUserFacingError(string? json, out string? message)
+    {
+        message = null;
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            json = json.TrimStart();
+            if (json.Length == 0 || json[0] != '{')
+            {
+                return false;
+            }
+
+            var response = JsonSerializer.Deserialize<VoidedHostApiResponse>(json, JsonOptions);
+            if (response == null || !IsTruthyError(response.Error))
+            {
+                return false;
+            }
+
+            var sb = new StringBuilder();
+
+            var main = response.Message?.Trim();
+            if (!string.IsNullOrEmpty(main))
+            {
+                sb.Append("voided.host: ").Append(main);
+            }
+
+            if (response.ErrorDetails != null)
+            {
+                foreach (var item in response.ErrorDetails)
+                {
+                    var detail = item.Message?.Trim();
+                    if (string.IsNullOrEmpty(detail))
+                    {
+                        continue;
+                    }
+
+                    if (string.Equals(detail, main, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (sb.Length > 0)
+                    {
+                        sb.Append(Environment.NewLine);
+                    }
+
+                    sb.Append(detail);
+                }
+            }
+
+            message = sb.Length > 0 ? sb.ToString() : "voided.host returned an error.";
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsTruthyError(JsonElement? errorElement)
+    {
+        if (errorElement == null || !errorElement.HasValue)
+        {
+            return false;
+        }
+
+        var tok = errorElement.Value;
+
+        return tok.ValueKind switch
+        {
+            JsonValueKind.Null or JsonValueKind.Undefined => false,
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Number => tok.TryGetInt64(out var n) && n != 0,
+            JsonValueKind.String => tok.GetString() is { } s &&
+                                    !string.IsNullOrEmpty(s.Trim()) &&
+                                    (s.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                                     (int.TryParse(s, out var parsed) && parsed != 0)),
+            _ => false
+        };
+    }
+
+    public static bool TryParseUploadResponse(string? json, out string? shareLink, out string? deletionUrl, out string? errorMessage)
+    {
+        shareLink = null;
+        deletionUrl = null;
+        errorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            var response = JsonSerializer.Deserialize<VoidedHostApiResponse>(json, JsonOptions);
+            if (response == null)
+            {
+                return false;
+            }
+
+            if (IsTruthyError(response.Error))
+            {
+                if (!TryBuildUserFacingError(json, out errorMessage) || string.IsNullOrEmpty(errorMessage))
+                {
+                    errorMessage = "voided.host returned an error.";
+                }
+
+                return false;
+            }
+
+            if (response.Data != null)
+            {
+                var sl = response.Data.ShareLink?.Trim();
+                if (!string.IsNullOrEmpty(sl))
+                {
+                    shareLink = sl;
+                }
+
+                if (response.Data.Id is { } idElement && idElement.ValueKind != JsonValueKind.Null && idElement.ValueKind != JsonValueKind.Undefined)
+                {
+                    var idPart = idElement.ToString();
+                    if (!string.IsNullOrEmpty(idPart))
+                    {
+                        deletionUrl = string.Format(VoidedHostUploader.ImageDeletionUrlFormat, idPart);
+                    }
+                }
+            }
+
+            return !string.IsNullOrEmpty(shareLink);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/SnapX.Core/Upload/Text/VoidedHostTextUploader.cs
+++ b/SnapX.Core/Upload/Text/VoidedHostTextUploader.cs
@@ -1,0 +1,66 @@
+
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using SnapX.Core.Upload.BaseServices;
+using SnapX.Core.Upload.BaseUploaders;
+using SnapX.Core.Upload.Img;
+using SnapX.Core.Upload.Utils;
+
+namespace SnapX.Core.Upload.Text;
+
+public class VoidedHostTextUploaderService : TextUploaderService
+{
+    public override TextDestination EnumValue => TextDestination.VoidedHost;
+
+    public override bool CheckConfig(UploadersConfig config) => VoidedHostUploader.IsUploadConfigured(config);
+
+    public override GenericUploader CreateUploader(UploadersConfig config, TaskReferenceHelper taskInfo)
+    {
+        bool useGuest = VoidedHostUploader.ShouldUseGuestMode(config);
+        string key = VoidedHostUploader.GetEffectiveUploadKey(config);
+
+        return new VoidedHostTextUploader(key, useGuest);
+    }
+}
+
+public sealed class VoidedHostTextUploader : TextUploader
+{
+    private readonly VoidedHostMultipartUploader _multipart;
+
+    public VoidedHostTextUploader(string uploadKey, bool useGuestMode)
+    {
+        _multipart = new VoidedHostMultipartUploader(uploadKey, useGuestMode, VoidedHostUploader.PasteUploadApiUrl);
+        _multipart.ProgressChanged += OnProgressChanged;
+        _multipart.EarlyURLCopyRequested += OnEarlyURLCopyRequested;
+    }
+
+    [RequiresDynamicCode("Uploader")]
+    [RequiresUnreferencedCode("Uploader")]
+    public override UploadResult UploadText(string? text, string? fileName)
+    {
+        Errors.Errors.Clear();
+        if (string.IsNullOrEmpty(fileName))
+        {
+            fileName = "paste.txt";
+        }
+        else if (!Path.HasExtension(fileName))
+        {
+            fileName += ".txt";
+        }
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(text ?? ""));
+        _multipart.BufferSize = BufferSize;
+        UploadResult result = _multipart.Upload(stream, fileName);
+        Errors.Add(_multipart.Errors);
+        return result;
+    }
+
+    public override void StopUpload()
+    {
+        _multipart.StopUpload();
+        base.StopUpload();
+    }
+}

--- a/SnapX.Core/Upload/UploaderCategory.cs
+++ b/SnapX.Core/Upload/UploaderCategory.cs
@@ -8,6 +8,8 @@ namespace SnapX.Core.Upload;
 /// </summary>
 public enum UploaderCategory
 {
+    [Description("Universal uploaders")]
+    UniversalUploaders,
     [Description("Image uploaders")]
     ImageUploaders,
     [Description("Text uploaders")]

--- a/SnapX.Core/Upload/UploaderFactory.cs
+++ b/SnapX.Core/Upload/UploaderFactory.cs
@@ -102,6 +102,7 @@ private static void Register<T>(T service) where T : IUploaderService
     Register(new SendSpaceFileUploaderService());
     Register(new SulFileUploaderService());
     Register(new Vault_oooFileUploaderService());
+    Register(new VoidedHostFileUploaderService());
     Register(new GooglePhotosImageUploaderService());
     Register(new CheveretoImageUploaderService());
     Register(new CustomImageUploaderService());
@@ -109,6 +110,7 @@ private static void Register<T>(T service) where T : IUploaderService
     Register(new ImageShackImageUploaderService());
     Register(new ImgurImageUploaderService());
     Register(new VgymeImageUploaderService());
+    Register(new VoidedHostImageUploaderService());
     Register(new CustomTextUploaderService());
     Register(new GitHubGistTextUploaderService());
     Register(new HastebinTextUploaderService());
@@ -116,6 +118,7 @@ private static void Register<T>(T service) where T : IUploaderService
     Register(new Paste2TextUploaderService());
     Register(new Paste_eeTextUploaderService());
     Register(new PastebinTextUploaderService());
+    Register(new VoidedHostTextUploaderService());
     Register(new YourlsURLShortenerService());
     Register(new ZeroWidthURLShortenerService());
     Register(new VURLShortenerService());

--- a/SnapX.Core/Upload/UploadersConfig.cs
+++ b/SnapX.Core/Upload/UploadersConfig.cs
@@ -65,6 +65,16 @@ public class UploadersConfig : SettingsBase<UploadersConfig>
 
     #endregion vgy.me
 
+    #region voided.host
+
+    [JsonEncrypt]
+    [YamlEncrypt]
+    public string VoidedHostUploadKey { get; set; } = "";
+
+    public bool VoidedHostUseGuest { get; set; } = true;
+
+    #endregion voided.host
+
     #endregion Image uploaders
 
     #region Text uploaders


### PR DESCRIPTION
Preface

SnapX did not have a built-in voided.host destination. voided.host supports image, text, and file uploads through one shared upload key, so adding it means implementing shared upload logic rather than three unrelated uploaders.

This change adds voided.host as a first-class SnapX uploader with encrypted config, AOT-friendly JSON parsing, and Avalonia settings UI.


Description of Change

Adds voided.host as a built-in uploader for image, text, and file destinations.

Core (SnapX.Core):
- Adds VoidedHost to ImageDestination, TextDestination, and FileDestination
- Adds VoidedHostUploadKey (encrypted) and VoidedHostUseGuest to UploadersConfig
- Implements VoidedHostUploader (images) with shared VoidedHostMultipartUploader and VoidedHostResponseParser
- Implements VoidedHostTextUploader (pastes) and VoidedHostFileUploader (files)
- Registers all three services in UploaderFactory
- Adds UniversalUploaders to UploaderCategory for settings navigation
- Adds [voided.host] debug logging for upload requests and API responses (status code, body preview, parse errors)

UI (SnapX.Avalonia):
- Adds a Universal uploaders section under Destinations with a single voided.host settings page instead of three duplicate entries
- Adds VoidedHostUploaderSettingsView for guest mode, upload key, and links to register or manage keys
- Wires the settings view in BuiltInUploaderSettingsView for all three voided.host uploader types

Uploads use multipart requests to api.voided.host with Authorization header auth, optional guest mode, and structured JSON error handling.


Possible Alternatives

Separate settings pages per destination type: rejected because voided.host uses one upload key for images, pastes, and files. Three pages would duplicate the same controls.

Single uploader class for all three types: rejected to stay consistent with SnapX's existing pattern of separate image, text, and file services, while sharing logic through VoidedHostMultipartUploader.


Implementation Details

Upload logic lives in VoidedHostMultipartUploader, which all three uploaders delegate to with different API URLs:

Image: https://api.voided.host/v2/images
Text: https://api.voided.host/v2/pastes
File: https://api.voided.host/v2/files

Multipart fields use p=snapx, v=1, and a timestamp. Guest mode is enabled when VoidedHostUseGuest is true and a guest API key is present in the build.

Settings are grouped under Universal uploaders because the configuration is destination-agnostic. voided.host still appears separately in the image, text, and file destination pickers when choosing where to upload.


Notes

- Guest upload depends on GuestUploadApiKey being set at build time. If it is empty, guest mode is disabled in the UI and CheckConfig requires a personal upload key.
- Debug logs use the [voided.host] prefix and include HTTP status codes and truncated response bodies to help diagnose API issues.
- UploaderFactory.cs was updated manually. Regenerating via the build tool will re-include the new services automatically.


Tested on

- [x] Windows — Version: 10.0.19045
- [ ] Linux — Distro & Version: N/A
- [ ] macOS — Version: N/A
- [ ] FreeBSD (optional) — Details: N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds voided.host as a shared image, text, and file destination with encrypted personal-key configuration and an Avalonia settings page. It also:
- Registers image, text, and file uploader services and destination enum values.
- Implements shared multipart request and JSON response handling.
- Adds a universal uploader settings category for the shared account configuration.
- Introduces guest uploads through a bundled shared authorization key.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the exposed shared guest credential is revoked and replaced with a design that does not distribute a reusable secret to clients.

The guest upload path embeds a reusable authorization value in public source, returns it as the effective upload key, and sends it directly to all three upload endpoints, allowing external abuse of the shared identity.

**Files Needing Attention:** SnapX.Core/Upload/Img/VoidedHostUploader.cs

<details open><summary><h3>Security Review</h3></summary>

The guest authorization credential is committed directly in source and transmitted as a bearer-style `Authorization` value. Anyone with the source or a distributed binary can reuse it outside SnapX to upload content under the shared guest identity. **How this was verified:** The constant returned by the guest-key selection path is passed verbatim into the multipart request's `Authorization` header.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SnapX.Core/Upload/Img/VoidedHostUploader.cs | Implements shared multipart transport, guest-key selection, and response parsing, but exposes the reusable guest authorization credential in public source and binaries. |
| SnapX.Core/Upload/Text/VoidedHostTextUploader.cs | Adds a text-upload wrapper that converts text to UTF-8 multipart content and delegates to the shared transport. |
| SnapX.Core/Upload/File/VoidedHostFileUploader.cs | Adds a file-upload wrapper with shared transport, progress forwarding, and cancellation delegation. |
| SnapX.Avalonia/Views/Settings/Views/ImageUploaders/VoidedHostUploaderSettingsView.axaml.cs | Connects shared guest-mode and personal-key controls to the global voided.host configuration. |
| SnapX.Core/Upload/UploaderFactory.cs | Registers all three new voided.host service implementations in their corresponding destination maps. |
| SnapX.Core/Upload/UploadersConfig.cs | Adds encrypted personal upload-key storage and a shared guest-mode preference. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    UI[voided.host settings] --> Config[Shared UploadersConfig]
    Config --> Factory[UploaderFactory]
    Factory --> Image[Image uploader]
    Factory --> Text[Text uploader]
    Factory --> File[File uploader]
    Image --> Multipart[Shared multipart uploader]
    Text --> Multipart
    File --> Multipart
    Config -->|Guest mode| GuestKey[Bundled guest key]
    Config -->|Personal mode| PersonalKey[Encrypted personal key]
    GuestKey --> Multipart
    PersonalKey --> Multipart
    Multipart --> API[api.voided.host]
    API --> Parser[Shared JSON response parser]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(upload): add voided.host uploaders ..."](https://github.com/snapxl/snapx/commit/bf6419afcf6ffdc54165d8a7e330dc1904c439d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55132303)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->